### PR TITLE
Fix appsctl link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Provision
 
-To provision this PR to AWS run `make dist` to generate the App bundle and then follow the steps [here].
+To provision this PR to AWS run `make dist` to generate the App bundle and then follow the steps [here](https://github.com/mattermost/mattermost-plugin-apps#provisioning).
 
 ## Configuration
 


### PR DESCRIPTION
#### Summary
Fix the link to the provisioning docs

#### Ticket Link
Follow up on https://github.com/mattermost/mattermost-app-servicenow/pull/2

