### PR TITLE
Don't push release bundle to S3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           paths:
             - "bundle.zip"
       - store_artifacts:
-          path: dist
+          path: dist/bundle.zip
 
 workflows:
   version: 2
@@ -77,15 +77,6 @@ workflows:
       - build
   ci:
     jobs:
-      - lint:
-          filters:
-            tags:
-              only: /^v.*/
-      - test:
-          filters:
-            tags:
-              only: /^v.*/
-      - build:
-          filters:
-            tags:
-              only: /^v.*/
+      - lint
+      - test
+      - build


### PR DESCRIPTION
#### Summary
Given that GitLab CI will be used to build the releases there is no need to upload the bundle any longer.

#### Ticket Link
None